### PR TITLE
Fix mlctl command line

### DIFF
--- a/mlctl/jobs/MlctlBatchJob.py
+++ b/mlctl/jobs/MlctlBatchJob.py
@@ -1,4 +1,4 @@
-from random_word import RandomWords
+from random_words import RandomWords
 import json
 
 from mlctl.jobs.common.helper import parse_infrastructure, parse_resources
@@ -12,8 +12,8 @@ class MlctlBatchJob():
             self.name = name
         else:
             # else make a new name randomly
-            words = RandomWords().get_random_words()
-            self.name = f'mlctl-batch-{words[1]}'
+            word = RandomWords().random_word()
+            self.name = f'mlctl-batch-{word}'
 
         self.job_type = job_type
         self.project = project

--- a/mlctl/jobs/MlctlDeployJob.py
+++ b/mlctl/jobs/MlctlDeployJob.py
@@ -1,5 +1,4 @@
 from random_words import RandomWords
-RandomWords().get_random_words()
 import json
 
 from mlctl.jobs.common.helper import parse_infrastructure, parse_resources
@@ -13,7 +12,7 @@ class MlctlDeployJob():
             self.name = name
         else:
             # else make a new name randomly
-            word = RandomWords().random_word('d')
+            word = RandomWords().random_word()
             self.name = f'mlctl-deploy-{word}'
 
         self.job_type = job_type

--- a/mlctl/jobs/MlctlProcessJob.py
+++ b/mlctl/jobs/MlctlProcessJob.py
@@ -12,7 +12,7 @@ class MlctlProcessJob():
             self.name = name
         else:
             # else make a new name randomly
-            word = RandomWords().random_word('p')
+            word = RandomWords().random_word()
             self.name = f'mlctl-process-{word}'
 
         self.job_type = job_type

--- a/mlctl/jobs/MlctlTrainJob.py
+++ b/mlctl/jobs/MlctlTrainJob.py
@@ -12,7 +12,7 @@ class MlctlTrainJob():
             self.name = name
         else:
             # else make a new name randomly
-            word = RandomWords().random_word('t')
+            word = RandomWords().random_word()
             self.name = f'mlctl-train-{word}'
 
         self.job_type = job_type

--- a/tests/clis/test_init.py
+++ b/tests/clis/test_init.py
@@ -26,34 +26,33 @@ class TestInitCli(unittest.TestCase):
         self.assertIn(
             "DEBUG - Creating ML Model project using template from", response.output)
 
-        self.assertTrue(filecmp.cmp(os.path.join(project_path, "model/predict.py"),
-                                    os.path.join(os.path.dirname(__file__), "mlctl_init/model/predict.py")))
+        template_path = os.path.join(os.path.dirname(__file__), '../../mlctl/clis/template/{{cookiecutter.package_name}}/')
 
-        self.assertTrue(filecmp.cmp(os.path.join(project_path, "model/train.py"),
-                                    os.path.join(os.path.dirname(__file__), "mlctl_init/model/train.py")))
+        cmp = filecmp.dircmp(project_path, template_path)
 
-        self.assertTrue(filecmp.cmp(os.path.join(project_path, "model/__init__.py"),
-                                    os.path.join(os.path.dirname(__file__), "mlctl_init/model/__init__.py")))
+        self.assertCountEqual(cmp.same_files, [".gitignore", "setup.cfg", "tox.ini"])
+        self.assertCountEqual(cmp.common_dirs, ["model", "tests"])
+        self.assertCountEqual(cmp.left_only, [])
+        self.assertCountEqual(cmp.right_only, [])
+        self.assertCountEqual(cmp.diff_files, ["README.md", "setup.py"])
 
-        self.assertTrue(os.path.exists(
-            os.path.join(project_path, "tests/__init__.py")))
-        self.assertTrue(os.path.exists(os.path.join(
-            project_path, "tests/test_sample_project.py")))
+        modeldircmp = filecmp.dircmp(os.path.join(project_path, "model"), os.path.join(template_path, "model"))
 
-        self.assertTrue(filecmp.cmp(os.path.join(project_path, ".gitignore"),
-                                    os.path.join(os.path.dirname(__file__), "mlctl_init/.gitignore")))
+        self.assertCountEqual(modeldircmp.same_files, ["deploy.py", "process.py", "train.py"])
+        self.assertCountEqual(modeldircmp.common_dirs, [])
+        self.assertCountEqual(modeldircmp.left_only, [])
+        self.assertCountEqual(modeldircmp.right_only, [])
+        self.assertCountEqual(modeldircmp.diff_files, ["__init__.py"])
 
-        self.assertTrue(filecmp.cmp(os.path.join(project_path, "README.md"),
-                                    os.path.join(os.path.dirname(__file__), "mlctl_init/README.md")))
+        testdircmp = filecmp.dircmp(os.path.join(project_path, "tests"), os.path.join(template_path, "tests"))
 
-        self.assertTrue(filecmp.cmp(os.path.join(project_path, "setup.cfg"),
-                                    os.path.join(os.path.dirname(__file__), "mlctl_init/setup.cfg")))
+        self.assertCountEqual(testdircmp.same_files, [])
+        self.assertCountEqual(testdircmp.common_dirs, [])
+        self.assertCountEqual(testdircmp.left_only, ["test_sample_project.py"])
+        self.assertCountEqual(testdircmp.right_only, ["test_{{cookiecutter.package_name.lower().replace(' ', '_').replace('-', '_')}}.py"])
+        self.assertCountEqual(testdircmp.diff_files, ["__init__.py"])
 
-        self.assertTrue(filecmp.cmp(os.path.join(project_path, "setup.py"),
-                                    os.path.join(os.path.dirname(__file__), "mlctl_init/setup.py")))
+        # TODO: test files that are different due to string replacement
 
-        self.assertTrue(filecmp.cmp(os.path.join(project_path, "tox.ini"),
-                                    os.path.join(os.path.dirname(__file__), "mlctl_init/tox.ini")))
-
-        # removes model code from local directory
+        # clean up generated files, TODO: move to final
         rmtree(str(project_path))


### PR DESCRIPTION
## mlctl Pull Request Template Guidelines

## Goals of this PR :tada:

Fix mlctl command line that crashes

repo:

% mlctl                                     
Traceback (most recent call last):
  File "/Users/clarenceng/opt/miniconda3/envs/mls/bin/mlctl", line 33, in <module>
    sys.exit(load_entry_point('mlctl', 'console_scripts', 'mlctl')())
  File "/Users/clarenceng/opt/miniconda3/envs/mls/bin/mlctl", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/Users/clarenceng/opt/miniconda3/envs/mls/lib/python3.7/site-packages/importlib_metadata/__init__.py", line 168, in load
    module = import_module(match.group('module'))
  File "/Users/clarenceng/opt/miniconda3/envs/mls/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/clarenceng/github/clarng/mlctl/mlctl/clis/cli.py", line 4, in <module>
    from mlctl.clis.train_cli import train
  File "/Users/clarenceng/github/clarng/mlctl/mlctl/clis/train_cli.py", line 5, in <module>
    from mlctl.clis.common.utils import determine_infra_plugin_from_job, parse_train_yamls, docker_instructions
  File "/Users/clarenceng/github/clarng/mlctl/mlctl/clis/common/utils.py", line 10, in <module>
    from mlctl.jobs.MlctlDeployJob import MlctlDeployJob
  File "/Users/clarenceng/github/clarng/mlctl/mlctl/jobs/MlctlDeployJob.py", line 2, in <module>
    RandomWords().get_random_words()
AttributeError: 'RandomWords' object has no attribute 'get_random_words'


Fix usage of RandomWorlds and also made it consistent between steps

Also went and fix test_init that is currently not passing - dircmp runs filecmp under the hood
test_cli passes now except for one that is broken due to refactoring 

## Things to check on :dart:


 * My Pull Request code follows the <b>coding standards</b> and <b>styles</b> of the project 
 * I have worked on unit tests and reviewed my code to the best of my ability 
 * I have used comments to help others understand my code better 
 * My changes are not generating new warnings 
 * I have added unit tests for both positive and negative test cases
 * All unit tests pass successfully before pushing the PR 
 * Overall code coverage and diff code coverage is above the minimum requirement
 * I have made sure all dependent downstream changes impacted by my PR are working 
